### PR TITLE
feat: Update Node version to LTS v22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pnpm-debug.log*
 #lockfiles - can be reenabled by user
 package-lock.json
 yarn.lock
+
+#astro
+.astro/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 // https://astro.build/config
 import react from "@astrojs/react";
-import vercel from "@astrojs/vercel/serverless";
+import vercel from "@astrojs/vercel";
 
 
 // https://astro.build/config

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/node": "^5.3.2",
-    "@astrojs/react": "^2.2.1",
-    "@astrojs/vercel": "^3.8.0",
+    "@astrojs/node": "^9.0.0",
+    "@astrojs/react": "^4.1.3",
+    "@astrojs/vercel": "^8.0.1",
     "@popperjs/core": "^2.11.8",
-    "astro": "^2.10.4",
+    "astro": "^5.1.5",
     "astro-seo-metadata": "^0.6.0",
     "buttercms": "^1.2.15",
     "react": "^18.2.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.8",
-    "@types/react": "^18.2.20"
+    "@types/react": "^19.0.4"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tiny-slider": "^2.9.4"
   },
   "devDependencies": {
-    "@types/node": "^18.11.8",
+    "@types/node": "^22.10.5",
     "@types/react": "^19.0.4"
   },
   "browserslist": {
@@ -37,5 +37,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
This PR updates and sets the minimal required Node version to LTS, more specifically to version 22.10.5.

Due to Node update, Astro version needed to be migrated to latest version due to its possible compatibility issues. Version compatibility of Astro to Node can be seen here: https://docs.astro.build/en/upgrade-astro/#nodejs-support-and-upgrade-policies.

To migrate Astro, we used Astro tool `@astrojs/upgrade`. For more information about specific version changes, you can look into migration documentation:
- v2 to v3: https://docs.astro.build/en/guides/upgrade-to/v3/
- v3 to v4: https://docs.astro.build/en/guides/upgrade-to/v4/
- v4 to v5: https://docs.astro.build/en/guides/upgrade-to/v5/

Looking into documentation above, major changes didn't affect the behaviour of Astro starter.